### PR TITLE
Fix contribution line

### DIFF
--- a/estella/estella/dllmain.c
+++ b/estella/estella/dllmain.c
@@ -27,7 +27,8 @@ static DWORD CALLBACK app_pre_startup(void)
     struct gfx_config gfx_cfg;
 
     dprintf("Project Estella - Segatools for Privileged Fuckers\n");
-    dprintf("Brought to you by: BemaniWitch, dogtopus, Felix, JamesLewisLiu, mariodon, Midorica, mon, Praxis, Raki, Shiz, Tau\n");
+    dprintf("Brought to you by: Raki\n");
+    dprintf("Original code by: BemaniWitch, dogtopus, Felix, JamesLewisLiu, mariodon, Midorica, mon, Praxis, Shiz, Tau\n");
     dprintf("--------------------------------------------------\n");
     dprintf("<< You should give money to poor people.          \n");
     dprintf("       The government should've taxed you more. >>\n");

--- a/estella/estella/dllmain.c
+++ b/estella/estella/dllmain.c
@@ -27,7 +27,7 @@ static DWORD CALLBACK app_pre_startup(void)
     struct gfx_config gfx_cfg;
 
     dprintf("Project Estella - Segatools for Privileged Fuckers\n");
-    dprintf("Copyright (C) DJHACKERS, Matt Bilker, Raki Saionji\n");
+    dprintf("Brought to you by: BemaniWitch, dogtopus, Felix, JamesLewisLiu, mariodon, Midorica, mon, Praxis, Raki, Shiz, Tau\n");
     dprintf("--------------------------------------------------\n");
     dprintf("<< You should give money to poor people.          \n");
     dprintf("       The government should've taxed you more. >>\n");


### PR DESCRIPTION
The included contribution line leaves out a number of contributors that have made separate contributions to the upstream project and they should be noted for their work on segatools.

Also, I could not test this project as it does not compile for me in VS 2019 with it saying `hooklib.x64.lib` could not be found.